### PR TITLE
Looking for multiverse_id so an empty card image gets skipped.

### DIFF
--- a/lib/mtgbot.js
+++ b/lib/mtgbot.js
@@ -160,7 +160,13 @@ MtgBot.prototype._lookupCard = function (message) {
   			//we found an exact match
   			if (data.length == 1){
   				var versions = data[0].editions;
-  				self._reply(message,message.channel[0],versions[0].image_url);	
+
+				for (var i=0; i < versions.length; i++) {
+					if (versions[i].multiverse_id !== 0) {
+						self._reply(message,message.channel[0],versions[0].image_url);
+					}
+				}
+
   			} else if (data.length > 1 ){
   				var matchedCard = data.filter(function(val){
   					return cardName.toLowerCase() === val.name.toLowerCase();


### PR DESCRIPTION
I think the fix is just a matter of a for loop running over each element in "editions" and making sure the multiverse_id is not 0 (like you mentioned in the chat) before displaying the image.
